### PR TITLE
Fix sample build error(vector drawable support)

### DIFF
--- a/gradle/android_common_config.gradle
+++ b/gradle/android_common_config.gradle
@@ -19,6 +19,7 @@ android {
     targetSdkVersion versions.compile_sdk
     versionCode versions.publish_version_code
     versionName versions.publish_version
+    vectorDrawables.useSupportLibrary = true
   }
 
   sourceSets {


### PR DESCRIPTION
Build failed due to the following error.
```
Caused by: org.gradle.api.GradleException: Can't process attribute android:fillColor="@color/icons_color": references to other resources are not supported by build-time PNG generation.
File was preprocessed as vector drawable support was added in Android 5.0 (API level 21)
```
