### PR TITLE
Update library to use ViewBinding instead of Layout IDs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,3 @@ subprojects {
     }
   }
 }
-
-task clean(type: Delete) {
-  delete rootProject.buildDir
-}

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
   }
   dependencies {
     classpath deps.gradle_plugins.android
-    classpath deps.gradle_plugins.bintray_release
+//    classpath deps.gradle_plugins.bintray_release
     classpath deps.gradle_plugins.kotlin
     classpath deps.gradle_plugins.spotless
     classpath deps.gradle_plugins.versions

--- a/core/src/main/java/com/afollestad/recyclical/BindingViewHolder.kt
+++ b/core/src/main/java/com/afollestad/recyclical/BindingViewHolder.kt
@@ -1,0 +1,5 @@
+package com.afollestad.recyclical
+
+import androidx.viewbinding.ViewBinding
+
+abstract class BindingViewHolder<VB: ViewBinding>(val binding: VB): ViewHolder(binding.root)

--- a/core/src/main/java/com/afollestad/recyclical/BindingViewHolder.kt
+++ b/core/src/main/java/com/afollestad/recyclical/BindingViewHolder.kt
@@ -1,5 +1,20 @@
+/**
+ * Designed and developed by Aidan Follestad (@afollestad)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.afollestad.recyclical
 
 import androidx.viewbinding.ViewBinding
 
-abstract class BindingViewHolder<VB: ViewBinding>(val binding: VB): ViewHolder(binding.root)
+abstract class BindingViewHolder<VB : ViewBinding>(val binding: VB) : ViewHolder(binding.root)

--- a/core/src/main/java/com/afollestad/recyclical/ItemDefinition.kt
+++ b/core/src/main/java/com/afollestad/recyclical/ItemDefinition.kt
@@ -18,9 +18,7 @@
 package com.afollestad.recyclical
 
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
-import androidx.annotation.LayoutRes
 import androidx.viewbinding.ViewBinding
 import com.afollestad.recyclical.itemdefinition.RealItemDefinition
 import com.afollestad.recyclical.viewholder.SelectionStateProvider
@@ -41,7 +39,7 @@ typealias RecycledCallback<VH> = (viewHolder: VH) -> Unit
  * @author Aidan Follestad (@afollestad)
  */
 @RecyclicalMarker
-interface ItemDefinition<out IT : Any, VH : ViewHolder, VB: ViewBinding> {
+interface ItemDefinition<out IT : Any, VH : ViewHolder, VB : ViewBinding> {
   /**
    * Sets a binder that binds this item to a view holder before being displayed in the
    * RecyclerView.
@@ -81,7 +79,7 @@ interface ItemDefinition<out IT : Any, VH : ViewHolder, VB: ViewBinding> {
  *
  * @author Aidan Follestad (@afollestad)
  */
-inline fun <reified IT : Any, VH : ViewHolder, VB: ViewBinding> RecyclicalSetup.withItem(
+inline fun <reified IT : Any, VH : ViewHolder, VB : ViewBinding> RecyclicalSetup.withItem(
   noinline layoutBinding: (LayoutInflater, ViewGroup, Boolean) -> VB,
   itemClassName: String = IT::class.java.name,
   noinline block: ItemDefinition<IT, VH, VB>.() -> Unit

--- a/core/src/main/java/com/afollestad/recyclical/Recyclical.kt
+++ b/core/src/main/java/com/afollestad/recyclical/Recyclical.kt
@@ -20,7 +20,6 @@ package com.afollestad.recyclical
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.annotation.LayoutRes
 import androidx.annotation.RestrictTo
 import androidx.annotation.RestrictTo.Scope.LIBRARY
 import androidx.recyclerview.widget.LinearLayoutManager

--- a/core/src/main/java/com/afollestad/recyclical/Recyclical.kt
+++ b/core/src/main/java/com/afollestad/recyclical/Recyclical.kt
@@ -17,13 +17,16 @@
 
 package com.afollestad.recyclical
 
+import android.view.LayoutInflater
 import android.view.View
+import android.view.ViewGroup
 import androidx.annotation.LayoutRes
 import androidx.annotation.RestrictTo
 import androidx.annotation.RestrictTo.Scope.LIBRARY
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.LayoutManager
+import androidx.viewbinding.ViewBinding
 import com.afollestad.recyclical.datasource.DataSource
 import com.afollestad.recyclical.handle.RealRecyclicalHandle
 import com.afollestad.recyclical.handle.RecyclicalHandle
@@ -118,9 +121,9 @@ class RecyclicalSetup internal constructor(
 
   /** This should not be called directly. */
   @RestrictTo(LIBRARY) fun registerItemDefinition(
-    @LayoutRes layoutRes: Int,
-    definition: ItemDefinition<*, *>
-  ) = itemGraph.register(layoutRes, definition)
+    layoutBinding: (LayoutInflater, ViewGroup, Boolean) -> ViewBinding,
+    definition: ItemDefinition<*, *, *>
+  ) = itemGraph.register(layoutBinding, definition)
 
   internal fun toAttached(): RecyclicalHandle {
     val dataSource = currentDataSource ?: error("Must set a data source.")

--- a/core/src/main/java/com/afollestad/recyclical/internal/DefinitionAdapter.kt
+++ b/core/src/main/java/com/afollestad/recyclical/internal/DefinitionAdapter.kt
@@ -73,9 +73,8 @@ internal open class DefinitionAdapter : RecyclerView.Adapter<ViewHolder>() {
     parent: ViewGroup,
     viewType: Int
   ): ViewHolder {
-    val layoutRes = itemGraph.layoutForType(viewType)
-    val view = LayoutInflater.from(parent.context)
-        .inflate(layoutRes, parent, false)
+    val layoutBindingFun = itemGraph.layoutForType(viewType)
+    val view = layoutBindingFun(LayoutInflater.from(parent.context), parent, false)
     return itemGraph.definitionForType(viewType)
         .createViewHolder(view)
   }

--- a/core/src/main/java/com/afollestad/recyclical/itemdefinition/ItemDefinitionExt.kt
+++ b/core/src/main/java/com/afollestad/recyclical/itemdefinition/ItemDefinitionExt.kt
@@ -21,7 +21,13 @@ import android.view.View
 import androidx.annotation.RestrictTo
 import androidx.annotation.RestrictTo.Scope.LIBRARY
 import androidx.viewbinding.ViewBinding
-import com.afollestad.recyclical.*
+import com.afollestad.recyclical.BindingViewHolder
+import com.afollestad.recyclical.ChildViewClickListener
+import com.afollestad.recyclical.ItemDefinition
+import com.afollestad.recyclical.R
+import com.afollestad.recyclical.ViewHolder
+import com.afollestad.recyclical.ViewHolderBinder
+import com.afollestad.recyclical.ViewHolderCreator
 import com.afollestad.recyclical.datasource.DataSource
 import com.afollestad.recyclical.datasource.SelectableDataSource
 import com.afollestad.recyclical.internal.makeBackgroundSelectable
@@ -30,7 +36,7 @@ import com.afollestad.recyclical.viewholder.NoSelectionStateProvider
 import com.afollestad.recyclical.viewholder.RealSelectionStateProvider
 import com.afollestad.recyclical.viewholder.SelectionStateProvider
 
-internal inline fun <reified VB: ViewBinding> ItemDefinition<*, *, *>.createViewHolder(itemBinding: VB): BindingViewHolder<VB> {
+internal inline fun <reified VB : ViewBinding> ItemDefinition<*, *, *>.createViewHolder(itemBinding: VB): BindingViewHolder<VB> {
   val realDefinition = realDefinition()
   val setup = realDefinition.setup
 
@@ -53,7 +59,7 @@ internal inline fun <reified VB: ViewBinding> ItemDefinition<*, *, *>.createView
       }
 }
 
-private inline fun <reified VB: ViewBinding> ItemDefinition<*, *, *>.setChildClickListeners(viewBinding: VB) {
+private inline fun <reified VB : ViewBinding> ItemDefinition<*, *, *>.setChildClickListeners(viewBinding: VB) {
   val realDefinition = realDefinition()
   if (realDefinition.childClickDataList.isEmpty()) {
     return
@@ -76,7 +82,7 @@ private inline fun <reified VB: ViewBinding> ItemDefinition<*, *, *>.setChildCli
   }
 }
 
-internal fun <VB: ViewBinding> ItemDefinition<*, *, VB>.bindViewHolder(
+internal fun <VB : ViewBinding> ItemDefinition<*, *, VB>.bindViewHolder(
   viewHolder: ViewHolder,
   item: Any,
   position: Int
@@ -99,7 +105,7 @@ internal fun ItemDefinition<*, *, *>.recycleViewHolder(viewHolder: ViewHolder) {
   realDefinition.onRecycled?.invoke(viewHolder)
 }
 
-internal fun <IT : Any, VH : ViewHolder, VB: ViewBinding> ItemDefinition<IT, VH, VB>.getSelectionStateProvider(
+internal fun <IT : Any, VH : ViewHolder, VB : ViewBinding> ItemDefinition<IT, VH, VB>.getSelectionStateProvider(
   position: Int
 ): SelectionStateProvider<IT> {
   val selectableSource = getDataSource<SelectableDataSource<*>, VB>()
@@ -117,7 +123,7 @@ internal fun View.viewHolder(): ViewHolder {
 }
 
 @RestrictTo(LIBRARY)
-fun <VB: ViewBinding> ItemDefinition<*, *, VB>.realDefinition(): RealItemDefinition<*, *, VB> {
+fun <VB : ViewBinding> ItemDefinition<*, *, VB>.realDefinition(): RealItemDefinition<*, *, VB> {
   return this as? RealItemDefinition<*, *, VB> ?: error("$this is not a RealItemDefinition")
 }
 
@@ -127,7 +133,7 @@ fun <VB: ViewBinding> ItemDefinition<*, *, VB>.realDefinition(): RealItemDefinit
  * @param view A lambda that provides the view we are attaching to in each view holder.
  * @param block A lambda executed when the view is clicked.
  */
-inline fun <IT : Any, reified VH : ViewHolder, VT : View, reified VB: ViewBinding> ItemDefinition<IT, VH, VB>.onChildViewClick(
+inline fun <IT : Any, reified VH : ViewHolder, VT : View, reified VB : ViewBinding> ItemDefinition<IT, VH, VB>.onChildViewClick(
   noinline view: VB.() -> VT,
   noinline block: ChildViewClickListener<IT, VT>
 ): ItemDefinition<IT, VH, VB> {
@@ -142,7 +148,7 @@ inline fun <IT : Any, reified VH : ViewHolder, VT : View, reified VB: ViewBindin
 }
 
 /** Gets the current data source, auto casting to the type [T]. */
-inline fun <reified T : DataSource<*>, VB: ViewBinding> ItemDefinition<*, *, VB>.getDataSource(): T? {
+inline fun <reified T : DataSource<*>, VB : ViewBinding> ItemDefinition<*, *, VB>.getDataSource(): T? {
   return if (this is RealItemDefinition) {
     currentDataSource as? T
   } else {

--- a/core/src/main/java/com/afollestad/recyclical/itemdefinition/ItemGraph.kt
+++ b/core/src/main/java/com/afollestad/recyclical/itemdefinition/ItemGraph.kt
@@ -18,7 +18,6 @@ package com.afollestad.recyclical.itemdefinition
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.annotation.CheckResult
-import androidx.annotation.LayoutRes
 import androidx.annotation.RestrictTo
 import androidx.annotation.RestrictTo.Scope.LIBRARY
 import androidx.annotation.VisibleForTesting

--- a/core/src/main/java/com/afollestad/recyclical/itemdefinition/ItemGraph.kt
+++ b/core/src/main/java/com/afollestad/recyclical/itemdefinition/ItemGraph.kt
@@ -15,11 +15,14 @@
  */
 package com.afollestad.recyclical.itemdefinition
 
+import android.view.LayoutInflater
+import android.view.ViewGroup
 import androidx.annotation.CheckResult
 import androidx.annotation.LayoutRes
 import androidx.annotation.RestrictTo
 import androidx.annotation.RestrictTo.Scope.LIBRARY
 import androidx.annotation.VisibleForTesting
+import androidx.viewbinding.ViewBinding
 import com.afollestad.recyclical.ItemDefinition
 
 /**
@@ -30,38 +33,38 @@ import com.afollestad.recyclical.ItemDefinition
 @RestrictTo(LIBRARY)
 class ItemGraph {
   @VisibleForTesting
-  internal val itemTypeToLayout = mutableMapOf<Int, Int>()
+  internal val itemTypeToLayout = mutableMapOf<Int, (LayoutInflater, ViewGroup, Boolean) -> ViewBinding>()
   @VisibleForTesting
-  internal var itemTypeToDefinition = mutableMapOf<Int, ItemDefinition<*, *>>()
+  internal var itemTypeToDefinition = mutableMapOf<Int, ItemDefinition<*, *, *>>()
 
   private var itemClassToType = mutableMapOf<String, Int>()
 
   fun register(
-    @LayoutRes layoutRes: Int,
-    definition: ItemDefinition<*, *>
+    layoutBinding: (LayoutInflater, ViewGroup, Boolean) -> ViewBinding,
+    definition: ItemDefinition<*, *, *>
   ) {
     val itemClassName = definition.realDefinition()
         .itemClassName
     val itemType = (itemTypeToLayout.keys.max() ?: 0) + 1
-    this.itemTypeToLayout[itemType] = layoutRes
+    this.itemTypeToLayout[itemType] = layoutBinding
     this.itemClassToType[itemClassName] = itemType
     this.itemTypeToDefinition[itemType] = definition
   }
 
-  @CheckResult @LayoutRes
-  fun layoutForType(type: Int): Int {
+  @CheckResult
+  fun layoutForType(type: Int): (LayoutInflater, ViewGroup, Boolean) -> ViewBinding {
     return itemTypeToLayout[type] ?: error(
         "Didn't find layout for type $type"
     )
   }
 
-  @CheckResult fun definitionForType(type: Int): ItemDefinition<*, *> {
+  @CheckResult fun definitionForType(type: Int): ItemDefinition<*, *, *> {
     return itemTypeToDefinition[type] ?: error(
         "Didn't find any definitions for type $type"
     )
   }
 
-  @CheckResult fun definitionForName(name: String): ItemDefinition<*, *> {
+  @CheckResult fun definitionForName(name: String): ItemDefinition<*, *, *> {
     val type = itemClassToType[name] ?: error(
         "Didn't find item type for class $name"
     )

--- a/core/src/main/java/com/afollestad/recyclical/itemdefinition/RealItemDefinition.kt
+++ b/core/src/main/java/com/afollestad/recyclical/itemdefinition/RealItemDefinition.kt
@@ -19,6 +19,7 @@ package com.afollestad.recyclical.itemdefinition
 
 import android.view.View
 import androidx.annotation.VisibleForTesting
+import androidx.viewbinding.ViewBinding
 import com.afollestad.recyclical.ChildViewClickListener
 import com.afollestad.recyclical.IdGetter
 import com.afollestad.recyclical.ItemClickListener
@@ -35,10 +36,10 @@ import com.afollestad.recyclical.viewholder.SelectionStateProvider
 
 /** @author Aidan Follestad (@afollestad) */
 @RecyclicalMarker
-class RealItemDefinition<out IT : Any, VH : ViewHolder>(
+class RealItemDefinition<out IT : Any, VH : ViewHolder, VB: ViewBinding>(
   internal val setup: RecyclicalSetup,
   val itemClassName: String
-) : ItemDefinition<IT, VH> {
+) : ItemDefinition<IT, VH, VB> {
 
   /** The current data source set in setup. */
   val currentDataSource: DataSource<*>?
@@ -49,7 +50,7 @@ class RealItemDefinition<out IT : Any, VH : ViewHolder>(
   @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
   internal var itemOnLongClick: ItemClickListener<Any>? = null
 
-  internal var creator: ViewHolderCreator<*>? = null
+  internal var creator: ((layoutBinding: VB) -> VH)? = null
   internal var binder: ViewHolderBinder<*, *>? = null
   internal var idGetter: IdGetter<Any>? = null
   internal var onRecycled: RecycledCallback<Any>? = null
@@ -57,25 +58,25 @@ class RealItemDefinition<out IT : Any, VH : ViewHolder>(
   var childClickDataList = mutableListOf<ChildClickData<*, *, *>>()
 
   override fun onBind(
-    viewHolderCreator: ViewHolderCreator<VH>,
+    viewHolderCreator: (layoutBinding: VB) -> VH,
     block: ViewHolderBinder<VH, IT>
-  ): ItemDefinition<IT, VH> {
+  ): ItemDefinition<IT, VH, VB> {
     this.creator = viewHolderCreator
     this.binder = block
     return this
   }
 
-  override fun onClick(block: ItemClickListener<IT>): ItemDefinition<IT, VH> {
+  override fun onClick(block: ItemClickListener<IT>): ItemDefinition<IT, VH, VB> {
     this.itemOnClick = (block as SelectionStateProvider<Any>.(Int) -> Unit)
     return this
   }
 
-  override fun onLongClick(block: ItemClickListener<IT>): ItemDefinition<IT, VH> {
+  override fun onLongClick(block: ItemClickListener<IT>): ItemDefinition<IT, VH, VB> {
     this.itemOnLongClick = (block as SelectionStateProvider<Any>.(Int) -> Unit)
     return this
   }
 
-  override fun hasStableIds(idGetter: IdGetter<IT>): ItemDefinition<IT, VH> {
+  override fun hasStableIds(idGetter: IdGetter<IT>): ItemDefinition<IT, VH, VB> {
     this.idGetter = idGetter as IdGetter<Any>
     return this
   }
@@ -109,9 +110,9 @@ class RealItemDefinition<out IT : Any, VH : ViewHolder>(
   }
 
   /** @author Aidan Follestad (@afollestad) */
-  data class ChildClickData<in IT : Any, VH : ViewHolder, VT : View>(
-    val viewHolderType: Class<VH>,
-    val child: (viewHolder: VH) -> VT,
+  data class ChildClickData<in IT : Any, VB : ViewBinding, VT : View>(
+    val viewBindingType: Class<VB>,
+    val child: (viewBinding: VB) -> VT,
     val callback: ChildViewClickListener<IT, VT>
   )
 }

--- a/core/src/main/java/com/afollestad/recyclical/itemdefinition/RealItemDefinition.kt
+++ b/core/src/main/java/com/afollestad/recyclical/itemdefinition/RealItemDefinition.kt
@@ -29,14 +29,13 @@ import com.afollestad.recyclical.RecyclicalMarker
 import com.afollestad.recyclical.RecyclicalSetup
 import com.afollestad.recyclical.ViewHolder
 import com.afollestad.recyclical.ViewHolderBinder
-import com.afollestad.recyclical.ViewHolderCreator
 import com.afollestad.recyclical.datasource.DataSource
 import com.afollestad.recyclical.internal.Debouncer
 import com.afollestad.recyclical.viewholder.SelectionStateProvider
 
 /** @author Aidan Follestad (@afollestad) */
 @RecyclicalMarker
-class RealItemDefinition<out IT : Any, VH : ViewHolder, VB: ViewBinding>(
+class RealItemDefinition<out IT : Any, VH : ViewHolder, VB : ViewBinding>(
   internal val setup: RecyclicalSetup,
   val itemClassName: String
 ) : ItemDefinition<IT, VH, VB> {

--- a/core/src/main/res/layout/test_item.xml
+++ b/core/src/main/res/layout/test_item.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android" android:orientation="vertical" android:layout_width="match_parent" android:layout_height="match_parent">
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"/>
+</LinearLayout>

--- a/core/src/test/java/com/afollestad/recyclical/RecyclicalTest.kt
+++ b/core/src/test/java/com/afollestad/recyclical/RecyclicalTest.kt
@@ -19,6 +19,8 @@ import android.view.View
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.LayoutManager
+import androidx.viewbinding.ViewBinding
+import com.afollestad.recyclical.databinding.TestItemBinding
 import com.afollestad.recyclical.datasource.DataSource
 import com.afollestad.recyclical.handle.RealRecyclicalHandle
 import com.afollestad.recyclical.handle.getDataSource
@@ -90,7 +92,7 @@ class RecyclicalTest {
         withLayoutManager(testLayoutManager)
         verify(recyclerView).layoutManager = same(testLayoutManager)
 
-        withItem<TestItem, TestViewHolder>(INFLATE_ITEM_LAYOUT_RES) {
+        withItem<TestItem, TestViewHolder, TestItemBinding>(TestItemBinding::inflate) {
           onBind(::TestViewHolder, binder)
           onClick(testItemClickListener)
           onLongClick(testItemLongClickListener)
@@ -100,7 +102,7 @@ class RecyclicalTest {
   }
 
   @Test fun `setup succeeds with required information`() {
-    var itemDefinition: ItemDefinition<*, *>? = null
+    var itemDefinition: ItemDefinition<*, *, *>? = null
     val handle = recyclerView.setup {
       adapterCreator = { adapter }
       withEmptyView(emptyView)
@@ -108,7 +110,7 @@ class RecyclicalTest {
       withClickListener(testGlobalClickListener)
       withLongClickListener(testGlobalLongClickListener)
 
-      itemDefinition = withItem<TestItem, TestViewHolder>(INFLATE_ITEM_LAYOUT_RES) {
+      itemDefinition = withItem<TestItem, TestViewHolder, TestItemBinding>(TestItemBinding::inflate) {
         onBind(::TestViewHolder, binder)
         onClick(testItemClickListener)
         onLongClick(testItemLongClickListener)
@@ -140,7 +142,7 @@ class RecyclicalTest {
       adapterCreator = { adapter }
       withDataSource(dataSource)
 
-      withItem<TestItem, TestViewHolder>(INFLATE_ITEM_LAYOUT_RES) {
+      withItem<TestItem, TestViewHolder, TestItemBinding>(TestItemBinding::inflate) {
         hasStableIds { it.id }
         onBind(::TestViewHolder, binder)
       }
@@ -158,11 +160,11 @@ class RecyclicalTest {
         adapterCreator = { adapter }
         withDataSource(dataSource)
 
-        withItem<TestItem, TestViewHolder>(INFLATE_ITEM_LAYOUT_RES) {
+        withItem<TestItem, TestViewHolder, TestItemBinding>(TestItemBinding::inflate) {
           onBind(::TestViewHolder, binder)
         }
 
-        withItem<TestItem2, TestViewHolder2>(INFLATE_ITEM_LAYOUT_RES_2) {
+        withItem<TestItem2, TestViewHolder2, TestItemBinding>(TestItemBinding::inflate) {
           hasStableIds { it.id }
           onBind(::TestViewHolder2, binder2)
         }
@@ -178,7 +180,7 @@ class RecyclicalTest {
     recyclerView.setup {
       adapterCreator = { adapter }
       withDataSource(dataSource)
-      withItem<TestItem, TestViewHolder>(INFLATE_ITEM_LAYOUT_RES) {
+      withItem<TestItem, TestViewHolder, TestItemBinding>(TestItemBinding::inflate) {
         onBind(::TestViewHolder, binder)
       }
 

--- a/core/src/test/java/com/afollestad/recyclical/itemdefinition/ItemGraphTest.kt
+++ b/core/src/test/java/com/afollestad/recyclical/itemdefinition/ItemGraphTest.kt
@@ -15,6 +15,10 @@
  */
 package com.afollestad.recyclical.itemdefinition
 
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.viewbinding.ViewBinding
+import com.afollestad.recyclical.databinding.TestItemBinding
 import com.afollestad.recyclical.testutil.assertEqualTo
 import com.afollestad.recyclical.testutil.assertFalse
 import com.afollestad.recyclical.testutil.assertSameAs
@@ -25,17 +29,17 @@ import com.nhaarman.mockitokotlin2.mock
 import java.lang.IllegalArgumentException
 import org.junit.Test
 
-private const val REAL_LAYOUT_RES_1 = 1024
+private val REAL_LAYOUT_RES_1: ((LayoutInflater, ViewGroup, Boolean) -> ViewBinding) = TestItemBinding::inflate
 private const val REAL_CLASS_NAME_1 = "com.afollestad.SomeClass1"
-private const val REAL_LAYOUT_RES_2 = 2048
+private val REAL_LAYOUT_RES_2: ((LayoutInflater, ViewGroup, Boolean) -> ViewBinding) = TestItemBinding::inflate
 private const val REAL_CLASS_NAME_2 = "com.afollestad.SomeClass2"
 
 class ItemGraphTest {
   private val graph = ItemGraph()
-  private val itemDefinitionNoIdGetter = mock<RealItemDefinition<*, *>> {
+  private val itemDefinitionNoIdGetter = mock<RealItemDefinition<*, *, *>> {
     on { itemClassName } doReturn REAL_CLASS_NAME_1
   }
-  private val itemDefinitionWithIdGetter = mock<RealItemDefinition<*, *>> {
+  private val itemDefinitionWithIdGetter = mock<RealItemDefinition<*, *, *>> {
     on { itemClassName } doReturn REAL_CLASS_NAME_2
     on { idGetter } doReturn { 5 }
   }

--- a/core/src/test/java/com/afollestad/recyclical/testdata/TestViewHolder.kt
+++ b/core/src/test/java/com/afollestad/recyclical/testdata/TestViewHolder.kt
@@ -17,15 +17,9 @@
 
 package com.afollestad.recyclical.testdata
 
-import android.view.View
-import android.widget.TextView
-import com.afollestad.recyclical.R
-import com.afollestad.recyclical.ViewHolder
+import com.afollestad.recyclical.BindingViewHolder
+import com.afollestad.recyclical.databinding.TestItemBinding
 
-class TestViewHolder(itemView: View) : ViewHolder(itemView) {
-  val title: TextView = itemView.findViewById(R.id.title)
-}
+class TestViewHolder(binding: TestItemBinding) : BindingViewHolder<TestItemBinding>(binding)
+class TestViewHolder2(binding: TestItemBinding) : BindingViewHolder<TestItemBinding>(binding)
 
-class TestViewHolder2(itemView: View) : ViewHolder(itemView) {
-  val title: TextView = itemView.findViewById(R.id.title)
-}

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,8 +2,8 @@ ext.versions = [
     min_sdk: 19,
     compile_sdk: 29,
     build_tools: '29.0.0',
-    publish_version: '1.1.1',
-    publish_version_code: 24
+    publish_version: '2.0.0',
+    publish_version_code: 25
 ]
 
 ext.deps = [

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -8,11 +8,11 @@ ext.versions = [
 
 ext.deps = [
     gradle_plugins: [
-        android: "com.android.tools.build:gradle:3.5.2",
+        android: "com.android.tools.build:gradle:4.1.0-rc01",
         kotlin: "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.61",
         spotless: "com.diffplug.spotless:spotless-plugin-gradle:3.26.1",
         versions: "com.github.ben-manes:gradle-versions-plugin:0.27.0",
-        bintray_release: "com.novoda:bintray-release:0.9.2"
+//        bintray_release: "com.novoda:bintray-release:0.9.2"
     ],
 
     androidx: [

--- a/gradle/android_bintray_config.gradle
+++ b/gradle/android_bintray_config.gradle
@@ -1,47 +1,47 @@
-if (!project.rootProject.file('local.properties').exists()) {
-  logger.warn("local.properties not found. Skipping Bintray Release setup.")
-  return
-}
-apply plugin: "com.novoda.bintray-release"
-
-def getBintrayUserAndKey() {
-  Properties properties = new Properties()
-  properties.load(project.rootProject.file("local.properties").newDataInputStream())
-  return [
-      properties.getProperty("bintray.user"),
-      properties.getProperty("bintray.apikey")
-  ]
-}
-
-if (versions == null || versions.publish_version == null) {
-  throw new IllegalStateException("Unable to reference publish_version!")
-} else if (module_group == null || module_name == null) {
-  throw new IllegalStateException("Must provide module_group and module_name!")
-}
-
-task checkBintrayConfig {
-  doLast {
-    def (user, key) = getBintrayUserAndKey()
-    if (user == null || user.isEmpty() ||
-        key == null || key.isEmpty()) {
-      throw new IllegalStateException("Must specify Bintray user/API key in your local.properties.")
-    }
-  }
-}
-
-afterEvaluate {
-  bintrayUpload.dependsOn checkBintrayConfig
-}
-
-def (user, key) = getBintrayUserAndKey()
-publish {
-  bintrayUser = user
-  bintrayKey = key
-  userOrg = "drummer-aidan"
-  groupId = module_group
-  artifactId = module_name
-  publishVersion = versions.publish_version
-  desc = "A Kotlin DSL API to make RecyclerViews easier to use and faster to setup."
-  website = 'https://github.com/afollestad/recyclical'
-  dryRun = false
-}
+//if (!project.rootProject.file('local.properties').exists()) {
+//  logger.warn("local.properties not found. Skipping Bintray Release setup.")
+//  return
+//}
+////apply plugin: "com.novoda.bintray-release"
+//
+//def getBintrayUserAndKey() {
+//  Properties properties = new Properties()
+//  properties.load(project.rootProject.file("local.properties").newDataInputStream())
+//  return [
+//      properties.getProperty("bintray.user"),
+//      properties.getProperty("bintray.apikey")
+//  ]
+//}
+//
+//if (versions == null || versions.publish_version == null) {
+//  throw new IllegalStateException("Unable to reference publish_version!")
+//} else if (module_group == null || module_name == null) {
+//  throw new IllegalStateException("Must provide module_group and module_name!")
+//}
+//
+//task checkBintrayConfig {
+//  doLast {
+//    def (user, key) = getBintrayUserAndKey()
+//    if (user == null || user.isEmpty() ||
+//        key == null || key.isEmpty()) {
+//      throw new IllegalStateException("Must specify Bintray user/API key in your local.properties.")
+//    }
+//  }
+//}
+//
+//afterEvaluate {
+//  bintrayUpload.dependsOn checkBintrayConfig
+//}
+//
+//def (user, key) = getBintrayUserAndKey()
+//publish {
+//  bintrayUser = user
+//  bintrayKey = key
+//  userOrg = "drummer-aidan"
+//  groupId = module_group
+//  artifactId = module_name
+//  publishVersion = versions.publish_version
+//  desc = "A Kotlin DSL API to make RecyclerViews easier to use and faster to setup."
+//  website = 'https://github.com/afollestad/recyclical'
+//  dryRun = false
+//}

--- a/gradle/android_common_config.gradle
+++ b/gradle/android_common_config.gradle
@@ -22,6 +22,10 @@ android {
     vectorDrawables.useSupportLibrary = true
   }
 
+  buildFeatures{
+    viewBinding = true
+  }
+
   sourceSets {
     main.res.srcDirs = [
         "src/main/res",

--- a/gradle/android_publishable_library_config.gradle
+++ b/gradle/android_publishable_library_config.gradle
@@ -1,4 +1,4 @@
 apply plugin: "com.android.library"
 
 apply from: rootProject.file("gradle/android_common_config.gradle")
-apply from: rootProject.file("gradle/android_bintray_config.gradle")
+//apply from: rootProject.file("gradle/android_bintray_config.gradle")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip

--- a/sample/src/main/java/com/afollestad/recyclicalsample/MainActivity.kt
+++ b/sample/src/main/java/com/afollestad/recyclicalsample/MainActivity.kt
@@ -17,6 +17,7 @@ package com.afollestad.recyclicalsample
 
 import android.os.Bundle
 import android.view.View
+import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import androidx.recyclerview.widget.RecyclerView
@@ -35,6 +36,7 @@ import com.afollestad.recyclical.viewholder.isSelected
 import com.afollestad.recyclical.withItem
 import com.afollestad.recyclicalsample.data.MyListItem
 import com.afollestad.recyclicalsample.data.MyViewHolder
+import com.afollestad.recyclicalsample.databinding.MyListItemBinding
 import com.afollestad.recyclicalsample.fragment.FragmentSampleActivity
 import com.afollestad.recyclicalsample.util.startActivity
 import com.afollestad.recyclicalsample.util.toast
@@ -98,11 +100,21 @@ class MainActivity : AppCompatActivity() {
       withEmptyView(emptyView)
       withDataSource(dataSource)
 
-      withItem<MyListItem, MyViewHolder>(R.layout.my_list_item) {
+      withItem<MyListItem, MyViewHolder, MyListItemBinding>(MyListItemBinding::inflate) {
         hasStableIds { it.id }
-        onBind(::MyViewHolder) { _, item -> bindMyListItem(item) }
+        onBind(::MyViewHolder) { _, item ->
+          binding.icon.setImageResource(
+              if(isSelected()){
+                R.drawable.check_circle
+              } else {
+                R.drawable.person
+              }
+          )
+          binding.title.text = item.title
+          binding.body.text = item.body
+        }
 
-        onChildViewClick(MyViewHolder::icon) { _, _ ->
+        onChildViewClick(MyListItemBinding::body) { _, _ ->
           toast("Clicked icon of ${item.title}!")
           toggleSelection()
         }
@@ -111,18 +123,6 @@ class MainActivity : AppCompatActivity() {
         onLongClick { toggleSelection() }
       }
     }
-  }
-
-  private fun MyViewHolder.bindMyListItem(item: MyListItem) {
-    icon.setImageResource(
-        if (isSelected()) {
-          R.drawable.check_circle
-        } else {
-          R.drawable.person
-        }
-    )
-    title.text = item.title
-    body.text = item.body
   }
 
   private fun SelectionStateProvider<MyListItem>.clickMyListItem(index: Int) {

--- a/sample/src/main/java/com/afollestad/recyclicalsample/MainActivity.kt
+++ b/sample/src/main/java/com/afollestad/recyclicalsample/MainActivity.kt
@@ -17,7 +17,6 @@ package com.afollestad.recyclicalsample
 
 import android.os.Bundle
 import android.view.View
-import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import androidx.recyclerview.widget.RecyclerView
@@ -104,7 +103,7 @@ class MainActivity : AppCompatActivity() {
         hasStableIds { it.id }
         onBind(::MyViewHolder) { _, item ->
           binding.icon.setImageResource(
-              if(isSelected()){
+              if (isSelected()) {
                 R.drawable.check_circle
               } else {
                 R.drawable.person

--- a/sample/src/main/java/com/afollestad/recyclicalsample/data/ViewHolders.kt
+++ b/sample/src/main/java/com/afollestad/recyclicalsample/data/ViewHolders.kt
@@ -18,14 +18,13 @@ package com.afollestad.recyclicalsample.data
 import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.viewbinding.ViewBinding
+import com.afollestad.recyclical.BindingViewHolder
 import com.afollestad.recyclical.ViewHolder
 import com.afollestad.recyclicalsample.R.id
+import com.afollestad.recyclicalsample.databinding.MyListItemBinding
 
-class MyViewHolder(itemView: View) : ViewHolder(itemView) {
-  val icon: ImageView = itemView.findViewById(id.icon)
-  val title: TextView = itemView.findViewById(id.title)
-  val body: TextView = itemView.findViewById(id.body)
-}
+class MyViewHolder(binding: MyListItemBinding): BindingViewHolder<MyListItemBinding>(binding)
 
 class MyViewHolder2(itemView: View) : ViewHolder(itemView) {
   val icon: ImageView = itemView.findViewById(id.icon)

--- a/sample/src/main/java/com/afollestad/recyclicalsample/data/ViewHolders.kt
+++ b/sample/src/main/java/com/afollestad/recyclicalsample/data/ViewHolders.kt
@@ -18,13 +18,12 @@ package com.afollestad.recyclicalsample.data
 import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
-import androidx.viewbinding.ViewBinding
 import com.afollestad.recyclical.BindingViewHolder
 import com.afollestad.recyclical.ViewHolder
 import com.afollestad.recyclicalsample.R.id
 import com.afollestad.recyclicalsample.databinding.MyListItemBinding
 
-class MyViewHolder(binding: MyListItemBinding): BindingViewHolder<MyListItemBinding>(binding)
+class MyViewHolder(binding: MyListItemBinding) : BindingViewHolder<MyListItemBinding>(binding)
 
 class MyViewHolder2(itemView: View) : ViewHolder(itemView) {
   val icon: ImageView = itemView.findViewById(id.icon)

--- a/sample/src/main/java/com/afollestad/recyclicalsample/data/ViewHolders.kt
+++ b/sample/src/main/java/com/afollestad/recyclicalsample/data/ViewHolders.kt
@@ -21,11 +21,9 @@ import android.widget.TextView
 import com.afollestad.recyclical.BindingViewHolder
 import com.afollestad.recyclical.ViewHolder
 import com.afollestad.recyclicalsample.R.id
+import com.afollestad.recyclicalsample.databinding.MyListItem2Binding
 import com.afollestad.recyclicalsample.databinding.MyListItemBinding
 
 class MyViewHolder(binding: MyListItemBinding) : BindingViewHolder<MyListItemBinding>(binding)
 
-class MyViewHolder2(itemView: View) : ViewHolder(itemView) {
-  val icon: ImageView = itemView.findViewById(id.icon)
-  val title: TextView = itemView.findViewById(id.title)
-}
+class MyViewHolder2(binding: MyListItem2Binding) : BindingViewHolder<MyListItem2Binding>(binding)

--- a/sample/src/main/java/com/afollestad/recyclicalsample/fragment/MainFragment.kt
+++ b/sample/src/main/java/com/afollestad/recyclicalsample/fragment/MainFragment.kt
@@ -33,6 +33,7 @@ import com.afollestad.recyclicalsample.data.MyListItem
 import com.afollestad.recyclicalsample.data.MyListItem2
 import com.afollestad.recyclicalsample.data.MyViewHolder
 import com.afollestad.recyclicalsample.data.MyViewHolder2
+import com.afollestad.recyclicalsample.databinding.MyListItemBinding
 import com.afollestad.recyclicalsample.util.toast
 
 class MainFragment : Fragment() {
@@ -57,7 +58,7 @@ class MainFragment : Fragment() {
       val newIndex = dataSource.size() + 1
       val title = "Item #$newIndex"
       dataSource.add(
-          if (newIndex % 2 == 0) {
+          if (newIndex % 2 == 0 || true) {
             MyListItem(newIndex, title, "Hello world #$newIndex")
           } else {
             MyListItem2(newIndex, title)
@@ -79,12 +80,14 @@ class MainFragment : Fragment() {
         }
       }
 
-      withItem<MyListItem, MyViewHolder>(R.layout.my_list_item) {
+      withItem<MyListItem, MyViewHolder, MyListItemBinding>(MyListItemBinding::inflate) {
         hasStableIds { it.id }
-        onBind(::MyViewHolder) { _, item ->
-          icon.setImageResource(R.drawable.person)
-          title.text = item.title
-          body.text = item.body
+        onBind(::MyViewHolder) { view, item ->
+          (binding as? MyListItemBinding)?.run {
+            icon.setImageResource(R.drawable.person)
+            title.text = item.title
+            body.text = item.body
+          }
         }
         onClick { index ->
           toast("Clicked $index: ${item.title} / ${item.body}")
@@ -94,16 +97,16 @@ class MainFragment : Fragment() {
         }
       }
 
-      withItem<MyListItem2, MyViewHolder2>(R.layout.my_list_item_2) {
-        hasStableIds { it.id }
-        onBind(::MyViewHolder2) { _, item ->
-          icon.setImageResource(R.drawable.person)
-          title.text = item.title
-        }
-        onClick { index ->
-          toast("Clicked $index: ${item.title}")
-        }
-      }
+//      withItem<MyListItem2, MyViewHolder2>(R.layout.my_list_item_2) {
+//        hasStableIds { it.id }
+//        onBind(::MyViewHolder2) { _, item ->
+//          icon.setImageResource(R.drawable.person)
+//          title.text = item.title
+//        }
+//        onClick { index ->
+//          toast("Clicked $index: ${item.title}")
+//        }
+//      }
     }
   }
 }

--- a/sample/src/main/java/com/afollestad/recyclicalsample/fragment/MainFragment.kt
+++ b/sample/src/main/java/com/afollestad/recyclicalsample/fragment/MainFragment.kt
@@ -32,6 +32,8 @@ import com.afollestad.recyclicalsample.R
 import com.afollestad.recyclicalsample.data.MyListItem
 import com.afollestad.recyclicalsample.data.MyListItem2
 import com.afollestad.recyclicalsample.data.MyViewHolder
+import com.afollestad.recyclicalsample.data.MyViewHolder2
+import com.afollestad.recyclicalsample.databinding.MyListItem2Binding
 import com.afollestad.recyclicalsample.databinding.MyListItemBinding
 import com.afollestad.recyclicalsample.util.toast
 
@@ -42,14 +44,14 @@ class MainFragment : Fragment() {
   private val dataSource = emptyDataSource()
 
   override fun onCreateView(
-    inflater: LayoutInflater,
-    container: ViewGroup?,
-    savedInstanceState: Bundle?
+      inflater: LayoutInflater,
+      container: ViewGroup?,
+      savedInstanceState: Bundle?
   ): View? = inflater.inflate(R.layout.main_fragment, container, false)
 
   override fun onViewCreated(
-    view: View,
-    savedInstanceState: Bundle?
+      view: View,
+      savedInstanceState: Bundle?
   ) {
     super.onViewCreated(view, savedInstanceState)
 
@@ -57,7 +59,7 @@ class MainFragment : Fragment() {
       val newIndex = dataSource.size() + 1
       val title = "Item #$newIndex"
       dataSource.add(
-          if (newIndex % 2 == 0 || true) {
+          if (newIndex % 2 == 0) {
             MyListItem(newIndex, title, "Hello world #$newIndex")
           } else {
             MyListItem2(newIndex, title)
@@ -82,7 +84,7 @@ class MainFragment : Fragment() {
       withItem<MyListItem, MyViewHolder, MyListItemBinding>(MyListItemBinding::inflate) {
         hasStableIds { it.id }
         onBind(::MyViewHolder) { view, item ->
-          (binding as? MyListItemBinding)?.run {
+          binding.run {
             icon.setImageResource(R.drawable.person)
             title.text = item.title
             body.text = item.body
@@ -96,16 +98,18 @@ class MainFragment : Fragment() {
         }
       }
 
-//      withItem<MyListItem2, MyViewHolder2>(R.layout.my_list_item_2) {
-//        hasStableIds { it.id }
-//        onBind(::MyViewHolder2) { _, item ->
-//          icon.setImageResource(R.drawable.person)
-//          title.text = item.title
-//        }
-//        onClick { index ->
-//          toast("Clicked $index: ${item.title}")
-//        }
-//      }
+      withItem<MyListItem2, MyViewHolder2, MyListItem2Binding>(MyListItem2Binding::inflate) {
+        hasStableIds { it.id }
+        onBind(::MyViewHolder2) { _, item ->
+          binding.run {
+            icon.setImageResource(R.drawable.person)
+            title.text = item.title
+          }
+        }
+        onClick { index ->
+          toast("Clicked $index: ${item.title}")
+        }
+      }
     }
   }
 }

--- a/sample/src/main/java/com/afollestad/recyclicalsample/fragment/MainFragment.kt
+++ b/sample/src/main/java/com/afollestad/recyclicalsample/fragment/MainFragment.kt
@@ -32,7 +32,6 @@ import com.afollestad.recyclicalsample.R
 import com.afollestad.recyclicalsample.data.MyListItem
 import com.afollestad.recyclicalsample.data.MyListItem2
 import com.afollestad.recyclicalsample.data.MyViewHolder
-import com.afollestad.recyclicalsample.data.MyViewHolder2
 import com.afollestad.recyclicalsample.databinding.MyListItemBinding
 import com.afollestad.recyclicalsample.util.toast
 

--- a/swipe/src/test/java/com/afollestad/recyclical/swipe/SwipePluginTest.kt
+++ b/swipe/src/test/java/com/afollestad/recyclical/swipe/SwipePluginTest.kt
@@ -18,6 +18,7 @@ package com.afollestad.recyclical.swipe
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.core.app.ApplicationProvider
+import com.afollestad.recyclical.databinding.TestItemBinding
 import com.afollestad.recyclical.datasource.DataSource
 import com.afollestad.recyclical.setup
 import com.afollestad.recyclical.swipe.SwipeLocation.LEFT
@@ -47,7 +48,7 @@ class SwipePluginTest {
   @Test fun `attaches to recycler view`() {
     recyclerView.setup {
       withDataSource(dataSource)
-      withItem<TestItem, TestViewHolder>(android.R.layout.simple_list_item_1) {
+      withItem<TestItem, TestViewHolder, TestItemBinding>(TestItemBinding::inflate) {
         onBind(::TestViewHolder) { _, _ -> }
       }
       withSwipeAction(LEFT, RIGHT) {}
@@ -66,7 +67,7 @@ class SwipePluginTest {
   @Test fun `left swipe direction`() {
     recyclerView.setup {
       withDataSource(dataSource)
-      withItem<TestItem, TestViewHolder>(android.R.layout.simple_list_item_1) {
+      withItem<TestItem, TestViewHolder, TestItemBinding>(TestItemBinding::inflate) {
         onBind(::TestViewHolder) { _, _ -> }
       }
       withSwipeAction(LEFT) {}
@@ -82,7 +83,7 @@ class SwipePluginTest {
   @Test fun `right swipe direction`() {
     recyclerView.setup {
       withDataSource(dataSource)
-      withItem<TestItem, TestViewHolder>(android.R.layout.simple_list_item_1) {
+      withItem<TestItem, TestViewHolder, TestItemBinding>(TestItemBinding::inflate) {
         onBind(::TestViewHolder) { _, _ -> }
       }
       withSwipeAction(RIGHT) {}
@@ -98,7 +99,7 @@ class SwipePluginTest {
   @Test fun `left and right swipe directions`() {
     recyclerView.setup {
       withDataSource(dataSource)
-      withItem<TestItem, TestViewHolder>(android.R.layout.simple_list_item_1) {
+      withItem<TestItem, TestViewHolder, TestItemBinding>(TestItemBinding::inflate) {
         onBind(::TestViewHolder) { _, _ -> }
       }
       withSwipeAction(LEFT, RIGHT) {}

--- a/swipe/src/test/java/com/afollestad/recyclical/swipe/testdata/TestViewHolder.kt
+++ b/swipe/src/test/java/com/afollestad/recyclical/swipe/testdata/TestViewHolder.kt
@@ -19,13 +19,10 @@ package com.afollestad.recyclical.swipe.testdata
 
 import android.view.View
 import android.widget.TextView
+import com.afollestad.recyclical.BindingViewHolder
 import com.afollestad.recyclical.R
 import com.afollestad.recyclical.ViewHolder
+import com.afollestad.recyclical.databinding.TestItemBinding
 
-class TestViewHolder(itemView: View) : ViewHolder(itemView) {
-  val title: TextView = itemView.findViewById(R.id.title)
-}
-
-class TestViewHolder2(itemView: View) : ViewHolder(itemView) {
-  val title: TextView = itemView.findViewById(R.id.title)
-}
+class TestViewHolder(binding: TestItemBinding) : BindingViewHolder<TestItemBinding>(binding)
+class TestViewHolder2(binding: TestItemBinding) : BindingViewHolder<TestItemBinding>(binding)


### PR DESCRIPTION
Hello, I've changed the library implementation so that it uses the new suggested ViewBinding instead of old findViewById() methods. The only problem is that with gradle 6+, the bintray plugin is not working, so I temporarily disabled it. I've also changed the tests so that they include the new ViewBinding implementation.
